### PR TITLE
Allow for simple additions of new tasks

### DIFF
--- a/config.py
+++ b/config.py
@@ -72,6 +72,8 @@ class ExperimentConfig:
     model_constructor_name: str = ""
     # Config setter function name. Must be registered using @registry.register_config_setter()
     config_setter_name: Optional[str] = None
+    # Task to run for decoding. Must have a function registered using @registry.register_task_data_getter(). Defaults to decoding word embeddings.
+    task_name: str = "word_embedding_decoding_task"
     # Parameters for this model. Can be any user-defined dictionary.
     model_params: dict = field(default_factory=lambda: {})
     # Parameters for training.

--- a/configs/neural_conv_decoder/neural_conv_decoder_placeholder.yml
+++ b/configs/neural_conv_decoder/neural_conv_decoder_placeholder.yml
@@ -1,0 +1,37 @@
+model_constructor_name: ensemble_pitom_model
+config_setter_name: neural_conv
+task_name: placeholder_task
+model_params:
+  conv_filters: 128
+  reg: 0.35
+  reg_head: 0
+  dropout: 0.2
+  num_models: 10
+  embedding_dim: 1
+training_params:
+  batch_size: 64
+  epochs: 10
+  learning_rate: 0.001
+  weight_decay: 0.0001
+  early_stopping_patience: 10
+  losses: [mse]
+  metrics: ["cosine_sim"]
+  early_stopping_metric: mse
+  n_folds: 5
+  min_lag: -2000
+  max_lag: 1100
+  lag_step_size: 200
+data_params:
+  # Cross model data_params
+  data_root: data
+  embedding_type: gpt-2xl
+  embedding_layer: 24
+  embedding_pca_dim: 50
+  window_width: 1.0
+  preprocessing_fn_name: preprocess_neural_data
+  subject_ids: [9]
+  channel_reg_ex: ^G([1-9]|[1-5][0-9]|6[0-4])$
+  # neural_conv_decoder specific config
+  preprocessor_params:
+    num_average_samples: 32
+trial_name: ensemble_model_10_placeholder

--- a/configs/neural_conv_decoder/neural_conv_decoder_placeholder.yml
+++ b/configs/neural_conv_decoder/neural_conv_decoder_placeholder.yml
@@ -21,6 +21,7 @@ training_params:
   min_lag: -2000
   max_lag: 1100
   lag_step_size: 200
+  smaller_is_better: true
 data_params:
   # Cross model data_params
   data_root: data

--- a/data_utils.py
+++ b/data_utils.py
@@ -97,7 +97,7 @@ def get_data(
 
         # Make sure the number of samples match
         assert data.shape[0] == selected_targets.shape[0], "Sample counts don't match"
-        if selected_words:
+        if selected_words is not None:
             assert data.shape[0] == selected_words.shape[0], "Words don't match"
 
         datas.append(data)

--- a/data_utils.py
+++ b/data_utils.py
@@ -4,10 +4,8 @@ import numpy as np
 import mne
 from mne_bids import BIDSPath
 import pandas as pd
-from sklearn.decomposition import PCA
 
 from config import DataParams
-import embeddings
 
 
 def load_raws(data_params: DataParams):
@@ -49,54 +47,6 @@ def load_raws(data_params: DataParams):
     return raws
 
 
-def load_word_data(data_params: DataParams):
-    """
-    Loads and processes word-level data and retrieves corresponding embeddings based on specified parameters.
-
-    This function performs the following steps:
-    1. Loads a transcript file containing token-level information.
-    2. Retrieves aligned embeddings for each token or word, depending on the specified embedding type.
-    3. Groups sub-token entries into full words using word indices.
-    4. Optionally applies PCA to reduce the dimensionality of the embeddings.
-
-    Args:
-        data_params (DataParams): Configuration object containing paths, embedding type, and PCA settings.
-
-    Returns:
-        Tuple[pd.DataFrame, np.ndarray]: A DataFrame containing word-level information (word, start time, end time),
-        and a NumPy array of corresponding word-level embeddings.
-    """
-    transcript_path = os.path.join(
-        data_params.data_root, "stimuli/gpt2-xl/transcript.tsv"
-    )
-
-    # Load transcript
-    df_contextual = pd.read_csv(transcript_path, sep="\t", index_col=0)
-
-    if data_params.embedding_type == "gpt-2xl":
-        aligned_embeddings = embeddings.get_gpt_2xl_embeddings(
-            df_contextual, data_params
-        )
-
-    # Group sub-tokens together into words.
-    df_word = df_contextual.groupby("word_idx").agg(
-        dict(word="first", start="first", end="last")
-    )
-
-    if data_params.embedding_type == "gpt-2xl":
-        df_word["embedding"] = list(aligned_embeddings)
-    if data_params.embedding_type == "glove":
-        df_word = embeddings.get_glove_embeddings(df_word, data_params)
-    elif data_params.embedding_type == "arbitrary":
-        df_word = embeddings.get_arbitrary_embeddings(df_word, data_params)
-
-    if data_params.embedding_pca_dim:
-        pca = PCA(n_components=data_params.embedding_pca_dim, svd_solver="auto")
-        df_word.embedding = list(pca.fit_transform(df_word.embedding.tolist()))
-
-    return df_word
-
-
 def get_data(
     lag,
     raws: list[mne.io.Raw],
@@ -110,7 +60,7 @@ def get_data(
     Args:
         lag: the lag relative to each word onset to gather data around
         raws: list of mne.Raw object holding electrode data
-        df_word: dataframe containing columns start, end, word, and embedding
+        df_word: dataframe containing columns start, end, word, and target
         window_width: the width of the window which is gathered around each word onset + lag
         preprocessing_fn: function to apply to epoch data.
             Should have contract:
@@ -137,14 +87,12 @@ def get_data(
         )
 
         data = epochs.get_data(copy=False)
-        selected_embeddings = df_word.embedding[epochs.selection]
+        selected_targets = df_word.target[epochs.selection]
 
         selected_words = df_word.word.to_numpy()[epochs.selection]
 
         # Make sure the number of samples match
-        assert (
-            data.shape[0] == selected_embeddings.shape[0]
-        ), "Sample counts don't match"
+        assert data.shape[0] == selected_targets.shape[0], "Sample counts don't match"
         assert data.shape[0] == selected_words.shape[0], "Words don't match"
 
         datas.append(data)
@@ -154,4 +102,4 @@ def get_data(
     if preprocessing_fn:
         datas = preprocessing_fn(datas, preprocessor_params)
 
-    return datas, selected_embeddings, selected_words
+    return datas, selected_targets, selected_words

--- a/data_utils.py
+++ b/data_utils.py
@@ -89,11 +89,16 @@ def get_data(
         data = epochs.get_data(copy=False)
         selected_targets = df_word.target[epochs.selection]
 
-        selected_words = df_word.word.to_numpy()[epochs.selection]
+        # TODO: Clean this up so we don't need to pass around this potentially None variable.
+        if "word" in df_word.columns:
+            selected_words = df_word.word.to_numpy()[epochs.selection]
+        else:
+            selected_words = None
 
         # Make sure the number of samples match
         assert data.shape[0] == selected_targets.shape[0], "Sample counts don't match"
-        assert data.shape[0] == selected_words.shape[0], "Words don't match"
+        if selected_words:
+            assert data.shape[0] == selected_words.shape[0], "Words don't match"
 
         datas.append(data)
 

--- a/decoding_utils.py
+++ b/decoding_utils.py
@@ -648,7 +648,8 @@ def run_training_over_lags(
             }
         )
         lag_metrics["lags"] = lag
-        lag_metrics["rocs"] = weighted_roc_mean
+        if weighted_roc_mean:
+            lag_metrics["rocs"] = weighted_roc_mean
 
         # Append new row to existing DataFrame and write to file
         existing_df = pd.concat(

--- a/decoding_utils.py
+++ b/decoding_utils.py
@@ -272,8 +272,6 @@ def train_decoding_model(
         history = {
             f"{phase}_{name}": [] for phase in ("train", "val") for name in metric_names
         }
-        history["train_loss"] = []
-        history["val_loss"] = []
         history["num_epochs"] = None
 
         loop = tqdm(range(training_params.epochs), desc=f"Lag {lag}, Fold {fold}")
@@ -319,8 +317,8 @@ def train_decoding_model(
 
         # record into cv_results
         for name in metric_names:
-            cv_results[f"train_{name}"].append(history[f"train_{name}"][-1])
-            cv_results[f"val_{name}"].append(max(history[f"val_{name}"]))
+            cv_results[f"train_{name}"].append(history[f"train_{name}"][best_epoch])
+            cv_results[f"val_{name}"].append(history[f"val_{name}"][best_epoch])
             cv_results[f"test_{name}"].append(test_mets[name])
         cv_results["num_epochs"].append(history["num_epochs"])
 

--- a/decoding_utils.py
+++ b/decoding_utils.py
@@ -272,6 +272,8 @@ def train_decoding_model(
         history = {
             f"{phase}_{name}": [] for phase in ("train", "val") for name in metric_names
         }
+        history["train_loss"] = []
+        history["val_loss"] = []
         history["num_epochs"] = None
 
         loop = tqdm(range(training_params.epochs), desc=f"Lag {lag}, Fold {fold}")

--- a/embeddings.py
+++ b/embeddings.py
@@ -93,7 +93,7 @@ def get_glove_embeddings(df_word, data_params: DataParams):
     df_word = df_word[df_word["in_glove"]].reset_index()
 
     glove_embeddings = np.stack(glove_embeddings)
-    df_word["embedding"] = list(glove_embeddings)
+    df_word["target"] = list(glove_embeddings)
 
     return df_word
 
@@ -138,6 +138,6 @@ def get_arbitrary_embeddings(df_word, data_params: DataParams):
         for idx in word_to_idx[word]:
             arbitrary_embeddings[idx] = arbitrary_embeddings_per_word[i]
 
-    df_word["embedding"] = list(arbitrary_embeddings)
+    df_word["target"] = list(arbitrary_embeddings)
 
     return df_word

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import numpy as np
 from config import ExperimentConfig
 import data_utils
 import decoding_utils
+import task_utils
 from loader import import_all_from_package
 import registry
 from config_utils import parse_known_args, load_config_with_overrides, get_nested_value
@@ -22,7 +23,9 @@ def main():
 
     # Load all data.
     raws = data_utils.load_raws(experiment_config.data_params)
-    df_word = data_utils.load_word_data(experiment_config.data_params)
+    df_word = registry.task_data_getter_registry[experiment_config.task_name](
+        experiment_config.data_params
+    )
 
     # Allow user defined function to alter config if necessary for their model.
     if experiment_config.config_setter_name:

--- a/main.py
+++ b/main.py
@@ -86,6 +86,7 @@ def main():
         df_word,
         preprocessing_fn,
         model_constructor_fn,
+        experiment_config.task_name,
         model_params=experiment_config.model_params,
         training_params=experiment_config.training_params,
         data_params=experiment_config.data_params,

--- a/registry.py
+++ b/registry.py
@@ -6,6 +6,8 @@ data_preprocessor_registry = {}
 config_setter_registry = {}
 # Registry of functions for metric calculations.
 metric_registry = {}
+# Registry of functions for loading task-specific word data.
+task_data_getter_registry = {}
 
 
 def register_model_constructor(name=None):
@@ -131,6 +133,43 @@ def register_metric(name=None):
     def decorator(fn):
         model_name = name or fn.__name__
         metric_registry[model_name] = fn
+        return fn
+
+    return decorator
+
+
+def register_task_data_getter(name=None):
+    """
+    Decorator to register a task data getter function that can substitute for the 
+    load_word_data function in data_utils.py.
+
+    The decorated function must follow the signature:
+        task_data_getter(data_params: DataParams) -> pd.DataFrame
+
+    Where:
+        - data_params: DataParams object containing parameters for data loading
+        - Returns: A pandas DataFrame with required columns: 'start', 'end', 'word', 'target'
+                  - start: Start time of the word/token
+                  - end: End time of the word/token  
+                  - word: The actual word/token text
+                  - target: The target variable for prediction tasks
+
+    This function provides a way to load task-specific word-level data that follows
+    the expected format for downstream processing while allowing customization of
+    data sources and preprocessing steps.
+
+    Args:
+        name (str, optional): Optional name to register the task data getter under.
+                              Defaults to the function's __name__.
+
+    Returns:
+        function: A decorator that registers the task data getter in
+                  task_data_getter_registry.
+    """
+
+    def decorator(fn):
+        task_data_getter_name = name or fn.__name__
+        task_data_getter_registry[task_data_getter_name] = fn
         return fn
 
     return decorator

--- a/registry.py
+++ b/registry.py
@@ -140,18 +140,16 @@ def register_metric(name=None):
 
 def register_task_data_getter(name=None):
     """
-    Decorator to register a task data getter function that can substitute for the 
-    load_word_data function in data_utils.py.
+    Decorator to register a task data getter function that gathers the data relevant for your task.
 
     The decorated function must follow the signature:
         task_data_getter(data_params: DataParams) -> pd.DataFrame
 
     Where:
         - data_params: DataParams object containing parameters for data loading
-        - Returns: A pandas DataFrame with required columns: 'start', 'end', 'word', 'target'
-                  - start: Start time of the word/token
-                  - end: End time of the word/token  
-                  - word: The actual word/token text
+        - Returns: A pandas DataFrame with required columns: 'start', 'target'
+                  - start: Time to center the neural data example around. Most likely the start time of the word/token but can vary depending on task.
+                  - word: The actual word/token text (Optional)
                   - target: The target variable for prediction tasks
 
     This function provides a way to load task-specific word-level data that follows

--- a/task_utils.py
+++ b/task_utils.py
@@ -8,7 +8,7 @@ import embeddings
 import registry
 
 
-@registry.task_data_getter_registry()
+@registry.register_task_data_getter()
 def word_embedding_decoding_task(data_params: DataParams):
     """
     Loads and processes word-level data and retrieves corresponding embeddings based on specified parameters.

--- a/task_utils.py
+++ b/task_utils.py
@@ -52,6 +52,6 @@ def word_embedding_decoding_task(data_params: DataParams):
 
     if data_params.embedding_pca_dim:
         pca = PCA(n_components=data_params.embedding_pca_dim, svd_solver="auto")
-        df_word["target"] = list(pca.fit_transform(df_word.embedding.tolist()))
+        df_word.target = list(pca.fit_transform(df_word.target.tolist()))
 
     return df_word

--- a/task_utils.py
+++ b/task_utils.py
@@ -1,0 +1,57 @@
+import os
+
+import pandas as pd
+from sklearn.decomposition import PCA
+
+from config import DataParams
+import embeddings
+import registry
+
+
+@registry.task_data_getter_registry()
+def word_embedding_decoding_task(data_params: DataParams):
+    """
+    Loads and processes word-level data and retrieves corresponding embeddings based on specified parameters.
+
+    This function performs the following steps:
+    1. Loads a transcript file containing token-level information.
+    2. Retrieves aligned embeddings for each token or word, depending on the specified embedding type.
+    3. Groups sub-token entries into full words using word indices.
+    4. Optionally applies PCA to reduce the dimensionality of the embeddings.
+
+    Args:
+        data_params (DataParams): Configuration object containing paths, embedding type, and PCA settings.
+
+    Returns:
+        Tuple[pd.DataFrame, np.ndarray]: A DataFrame containing word-level information (word, start time, end time),
+        and a NumPy array of corresponding word-level embeddings.
+    """
+    transcript_path = os.path.join(
+        data_params.data_root, "stimuli/gpt2-xl/transcript.tsv"
+    )
+
+    # Load transcript
+    df_contextual = pd.read_csv(transcript_path, sep="\t", index_col=0)
+
+    if data_params.embedding_type == "gpt-2xl":
+        aligned_embeddings = embeddings.get_gpt_2xl_embeddings(
+            df_contextual, data_params
+        )
+
+    # Group sub-tokens together into words.
+    df_word = df_contextual.groupby("word_idx").agg(
+        dict(word="first", start="first", end="last")
+    )
+
+    if data_params.embedding_type == "gpt-2xl":
+        df_word["embedding"] = list(aligned_embeddings)
+    if data_params.embedding_type == "glove":
+        df_word = embeddings.get_glove_embeddings(df_word, data_params)
+    elif data_params.embedding_type == "arbitrary":
+        df_word = embeddings.get_arbitrary_embeddings(df_word, data_params)
+
+    if data_params.embedding_pca_dim:
+        pca = PCA(n_components=data_params.embedding_pca_dim, svd_solver="auto")
+        df_word.target = list(pca.fit_transform(df_word.embedding.tolist()))
+
+    return df_word

--- a/task_utils.py
+++ b/task_utils.py
@@ -44,7 +44,7 @@ def word_embedding_decoding_task(data_params: DataParams):
     )
 
     if data_params.embedding_type == "gpt-2xl":
-        df_word["embedding"] = list(aligned_embeddings)
+        df_word["target"] = list(aligned_embeddings)
     if data_params.embedding_type == "glove":
         df_word = embeddings.get_glove_embeddings(df_word, data_params)
     elif data_params.embedding_type == "arbitrary":
@@ -52,6 +52,6 @@ def word_embedding_decoding_task(data_params: DataParams):
 
     if data_params.embedding_pca_dim:
         pca = PCA(n_components=data_params.embedding_pca_dim, svd_solver="auto")
-        df_word.target = list(pca.fit_transform(df_word.embedding.tolist()))
+        df_word["target"] = list(pca.fit_transform(df_word.embedding.tolist()))
 
     return df_word


### PR DESCRIPTION
This PR adds a new registry for adding new tasks. The way we do this is by allowing for new functions to be written which are only required to return a pandas Dataframe which specify a start time and a target variable for each time. 

A task_data_getter can be registered using register_task_data_getter in registry.py. See there for more details. Basically any task_data_getter needs to take in a DataParams config object which  you define in your config file and return a pandas Dataframe describing how the input and target data for your model should be constructed. 

With this and a defined decoder model, data processing function, and a custom metric function (all already supported in their own registries. check the current docs for details on those) I believe you should be able to train and test basically any model on most tasks we can come up with. Below I give some examples to make this more concrete.

## Examples
This is the simplest possible example:

```
@registry.register_task_data_getter()
def placeholder_task(data_params: DataParams):
    # Just an example of the bare minimum of what's needed for
    transcript_path = os.path.join(
        data_params.data_root, "stimuli/gpt2-xl/transcript.tsv"
    )

    # Load transcript
    df_contextual = pd.read_csv(transcript_path, sep="\t", index_col=0)

    # Group sub-tokens together into words.
    df_word = df_contextual.groupby("word_idx").agg(dict(start="first"))

    # Just fill in a 1 for the column "target" since this is a placeholder. Model will learn to always output 1.
    df_word["target"] = 1.0

    # So now our dataframe has columns start and target and we can pass it into our training code.
    return df_word
```

Here we create a dataframe that only has two columns: start and target. Start tells the code what time we should gather neural data around. Here we use the word onset time but you could use any potential time in the neural data. This allows us to decouple from word onsets so you could potentially do a task like word vs. non-word since you can return any start time, not necessarily a word start. The target variable here is just set to always be 1, so we will train our model to always return 1 (verified this works). This though could be any possible value, for example the current volume at that time or a one-hot vector specifying the part of speech of the word. 

For a more real example this is how it's setup for the word embedding decoding task:

```
@registry.register_task_data_getter()
def word_embedding_decoding_task(data_params: DataParams):
    """
    Loads and processes word-level data and retrieves corresponding embeddings based on specified parameters.

    This function performs the following steps:
    1. Loads a transcript file containing token-level information.
    2. Retrieves aligned embeddings for each token or word, depending on the specified embedding type.
    3. Groups sub-token entries into full words using word indices.
    4. Optionally applies PCA to reduce the dimensionality of the embeddings.

    Args:
        data_params (DataParams): Configuration object containing paths, embedding type, and PCA settings.

    Returns:
        Tuple[pd.DataFrame, np.ndarray]: A DataFrame containing word-level information (word, start time, end time),
        and a NumPy array of corresponding word-level embeddings under the header target.
    """
    transcript_path = os.path.join(
        data_params.data_root, "stimuli/gpt2-xl/transcript.tsv"
    )

    # Load transcript
    df_contextual = pd.read_csv(transcript_path, sep="\t", index_col=0)

    if data_params.embedding_type == "gpt-2xl":
        aligned_embeddings = embeddings.get_gpt_2xl_embeddings(
            df_contextual, data_params
        )

    # Group sub-tokens together into words.
    df_word = df_contextual.groupby("word_idx").agg(
        dict(word="first", start="first", end="last")
    )

    if data_params.embedding_type == "gpt-2xl":
        df_word["target"] = list(aligned_embeddings)
    if data_params.embedding_type == "glove":
        df_word = embeddings.get_glove_embeddings(df_word, data_params)
    elif data_params.embedding_type == "arbitrary":
        df_word = embeddings.get_arbitrary_embeddings(df_word, data_params)

    if data_params.embedding_pca_dim:
        pca = PCA(n_components=data_params.embedding_pca_dim, svd_solver="auto")
        df_word.target = list(pca.fit_transform(df_word.target.tolist()))

    return df_word
```

Here I set 'start' to the word onset and 'target' to the associated word embeddings. I also use the 'word' column to attach the textual word for that sample which allows for further configuration and functionality like zero-shot testing.

All you need to do to work with your own tasks is to define a preprocessing_fn which handles setting up the data in the format for your model, a model_constructor_fn of a decoder which returns data in the right shape to compare to your target, and metric functions that calculate the metrics you care about. For my placeholder one above I can write the following config:

```
model_constructor_name: ensemble_pitom_model
config_setter_name: neural_conv
task_name: placeholder_task
model_params:
  conv_filters: 128
  reg: 0.35
  reg_head: 0
  dropout: 0.2
  num_models: 10
  embedding_dim: 1
training_params:
  batch_size: 64
  epochs: 10
  learning_rate: 0.001
  weight_decay: 0.0001
  early_stopping_patience: 10
  losses: [mse]
  metrics: ["cosine_sim"]
  early_stopping_metric: mse
  n_folds: 5
  min_lag: -2000
  max_lag: 1100
  lag_step_size: 200
  smaller_is_better: true
data_params:
  # Cross model data_params
  data_root: data
  embedding_type: gpt-2xl
  embedding_layer: 24
  embedding_pca_dim: 50
  window_width: 1.0
  preprocessing_fn_name: preprocess_neural_data
  subject_ids: [9]
  channel_reg_ex: ^G([1-9]|[1-5][0-9]|6[0-4])$
  # neural_conv_decoder specific config
  preprocessor_params:
    num_average_samples: 32
trial_name: ensemble_model_10_placeholder
```

Here I tell it to use the ensemble_pitom_model, use the mse as a loss (defined in metrics.py), track the cosine_sim metric as well, and customize my decoder to output a embedding_dim=1 since our target is just a single number. From this I can train my model over the data. 

I think this should be pretty useful and lead to the minimal code changes to add new tasks. Let me know what you think!
 